### PR TITLE
Add permissions and validation: only owners can update/delete, enforc…

### DIFF
--- a/books/permissions.py
+++ b/books/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework import permissions
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission:
+    - Read-only for everyone (GET, HEAD, OPTIONS).
+    - Write (PUT, PATCH, DELETE) only allowed for the owner.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # SAFE_METHODS = GET, HEAD, OPTIONS (always allowed)
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        # Write permissions only for the owner
+        return obj.user == request.user

--- a/books/views.py
+++ b/books/views.py
@@ -1,20 +1,35 @@
-from rest_framework import viewsets, filters
+from rest_framework import viewsets, filters, permissions
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from .models import Book
 from .serializers import BookSerializer
+from books.permissions import IsOwnerOrReadOnly
+
 
 class BookViewSet(viewsets.ModelViewSet):
     """
     ViewSet for handling CRUD operations for Books.
     - Anyone can list and search books (read-only).
-    - Only logged-in users can create, update, or delete books.
+    - Only logged-in users can create books.
+    - Only the book owner can update or delete their book.
     """
 
     queryset = Book.objects.all().order_by('-created_at')
     serializer_class = BookSerializer
-    permission_classes = [IsAuthenticatedOrReadOnly]  # secure create/update/delete
 
-    # search functionality (by title or author)
+    # Permissions:
+    # Anyone can read (GET)
+    # Logged-in users can create (POST)
+    #  Only the owner can update/delete (PUT/PATCH/DELETE)
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
+
+    def perform_create(self, serializer):
+        """
+        Automatically assign the logged-in user as the book owner
+        when a new book is created.
+        """
+        serializer.save(user=self.request.user)
+
+    # Search & ordering functionality
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
-    search_fields = ['title', 'author']  # users can search by title or author
-    ordering_fields = ['rating', 'created_at']  # allow sorting by rating or created date
+    search_fields = ['title', 'author']  # Search by title or author
+    ordering_fields = ['rating', 'created_at']  # Allow sorting by rating or creation date

--- a/reviews/serializers.py
+++ b/reviews/serializers.py
@@ -7,3 +7,9 @@ class ReviewSerializer(serializers.ModelSerializer):
         model = Review
         fields = '__all__'  # include all model fields in the API response
         read_only_fields = ('user',)  # user is set automatically
+
+    def validate_rating(self, value):
+        """Ensure rating is between 1 and 5."""
+        if value < 1 or value > 5:
+            raise serializers.ValidationError("Rating must be between 1 and 5.")
+        return value


### PR DESCRIPTION
##  Feature: Permissions & Validation

### Implemented
- **Permissions**
  - Only the **owner** of a book/review can update or delete it.
  - All users (authenticated or not) can still **view/list** books and reviews.
  - Ensures stronger data protection and prevents unauthorized modifications.

- **Validation**
  - Rating field now validated to **accept values only between 1 and 5**.
  - Prevents invalid review submissions (e.g., rating = 10).

- **BookViewSet & ReviewViewSet**
  - Integrated `IsOwnerOrReadOnly` custom permission.
  - Combined with `IsAuthenticatedOrReadOnly` so:
    - Anyone can read (safe methods).
    - Only logged-in users can create.
    - Only the owner can update/delete.

### Endpoints Impacted
- **Books**
  - `PUT /api/books/{id}/` → Update (owner only).
  - `DELETE /api/books/{id}/` → Delete (owner only).
- **Reviews**
  - `PUT /api/reviews/{id}/` → Update (owner only).
  - `DELETE /api/reviews/{id}/` → Delete (owner only).

###  Testing
- Tried updating/deleting another user’s book/review → returns **403 Forbidden**.
- Tried creating a review with `rating = 10` →  validation error raised.
- Normal create/update/delete with correct user → works successfully.

---

This feature enforces proper ownership rules and data validation across the system.
